### PR TITLE
[REFACTOR] Ingress 자원을 IngressController가 프로비저닝하지 못하는 현상 수정

### DIFF
--- a/values/koo-blog-api/values.yaml
+++ b/values/koo-blog-api/values.yaml
@@ -34,21 +34,25 @@ deployment:
 service:
   type: ClusterIP
   ports:
-    - port: 443
+    - port: 80
       targetPort: 8080
       protocol: TCP
 
 ingress:
   enabled: true
   className: alb
-  annotations: {}
+  annotations:
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-2:122976268003:certificate/6dbf0a97-5175-4cb5-a52f-8df33809a17e
+    alb.ingress.kubernetes.io/healthcheck-path: /hello
+    alb.ingress.kubernetes.io/healthcheck-port: '8080'
+    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
   hosts:
     - host: koo-blog.com
       paths:
         - path: /
           pathType: Prefix
-  tls:
-    - secretName: koo-blog-tls
-      hosts:
-        - koo-blog.com
+  tls: []
         


### PR DESCRIPTION
## 작업내용
1. Ingress 자원에 라우팅 규칙 정의
2. Ingress 자원에 TLS ARN 자원 위치 정의